### PR TITLE
chore: release v0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.2](https://github.com/codersparks-aoc/cargo-advent/compare/v0.0.1...v0.0.2) - 2025-09-19
+
+### Added
+
+- Added release-plz to handle releases

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "cargo-advent"
-version = "0.0.1"
+version = "0.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-advent"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2024"
 authors = ["codersparks <codersparks@users.noreply.github.com>"]
 description = "Yet another cli to help with Advent of Code challenges"


### PR DESCRIPTION



## 🤖 New release

* `cargo-advent`: 0.0.1 -> 0.0.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.2](https://github.com/codersparks-aoc/cargo-advent/compare/v0.0.1...v0.0.2) - 2025-09-19

### Added

- Added release-plz to handle releases
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).