### PR TITLE
chore: release v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.3](https://github.com/codersparks-aoc/cargo-advent/compare/v0.0.2...v0.0.3) - 2025-09-21
+
+### Added
+
+- Updated readme to include the fact that this has been implemented
+
+### Other
+
+- Added basic ability to generate aoc project from the command line
+- Started to implement the generate function
+
 ## [0.0.2](https://github.com/codersparks-aoc/cargo-advent/compare/v0.0.1...v0.0.2) - 2025-09-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cargo-advent"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "cargo-generate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-advent"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2024"
 authors = ["codersparks <codersparks@users.noreply.github.com>"]
 description = "Yet another cli to help with Advent of Code challenges"


### PR DESCRIPTION



## 🤖 New release

* `cargo-advent`: 0.0.2 -> 0.0.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.3](https://github.com/codersparks-aoc/cargo-advent/compare/v0.0.2...v0.0.3) - 2025-09-21

### Added

- Updated readme to include the fact that this has been implemented

### Other

- Added basic ability to generate aoc project from the command line
- Started to implement the generate function
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).