### PR TITLE
chore: release v0.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,12 @@ target
 # Added by cargo
 
 /target
+
+# Local settings
+
+# To aid in dev we use a config that outputs generated projects to a 'dev-output' folder therefore we ignore anything in
+# that folder
+/dev-output
+# We use a .env file to configure command line options during development testing so we .gitignore, however a common
+# file is stored in examples/env/.env-example
+.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/codersparks-aoc/cargo-advent/compare/v0.1.0...v0.2.0) - 2025-09-23
+
+### Added
+
+- Allowed config of clap by env vars from .env file
+
+### Other
+
+- reworded tickets to issues in readme
+- Updated readme with links to issues
+
 ## [0.1.0](https://github.com/codersparks-aoc/cargo-advent/compare/v0.0.2...v0.1.0) - 2025-09-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cargo-advent"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "cargo-generate",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,7 @@ dependencies = [
  "chrono",
  "clap",
  "lazy_static",
+ "loadenv",
  "regex",
  "shlex",
  "test-log",
@@ -489,7 +490,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -562,7 +563,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1182,7 +1183,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1368,6 +1369,12 @@ name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+
+[[package]]
+name = "loadenv"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a30d199872b1144f39cc1900cc6130ebc74d6451e4184b73f77704d6ca2c30"
 
 [[package]]
 name = "lock_api"
@@ -1806,7 +1813,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -2039,7 +2046,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2575,7 +2582,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-advent"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 authors = ["codersparks <codersparks@users.noreply.github.com>"]
 description = "Yet another cli to help with Advent of Code challenges"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 
 [dependencies]
 chrono = "0.4.42"
-clap = { version = "4.5.48", features = ["derive"] }
+clap = { version = "4.5.48", features = ["derive", "env"] }
 thiserror = "2.0.16"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.20"
@@ -28,6 +28,7 @@ regex = "1.11.2"
 lazy_static = "1.5.0"
 cargo-generate = "0.23.5"
 anyhow = "1.0.100"
+loadenv = "0.1.4"
 
 [dev-dependencies]
 shlex = "1.3.0"

--- a/README.md
+++ b/README.md
@@ -16,3 +16,45 @@ This cli will (eventually):
 | Allow user to download input files to the repo to allow testing                                         | https://github.com/codersparks-aoc/cargo-advent/issues/8<br>https://github.com/codersparks-aoc/cargo-advent/issues/10 |        N/A         |
 | Submit output for solution to the AOC website                                                           |                               https://github.com/codersparks-aoc/cargo-advent/issues/9                                |        N/A         |
 | Benchmark the solutions                                                                                 |                               https://github.com/codersparks-aoc/cargo-advent/issues/11                               |        N/A         |
+
+## Usage
+
+The application uses subcommands to run different actions. as described below. Each subcommand has its own help
+available by running `cargo-advent <subcommand> --help`. All command line arguments/options are configurable via
+environment variables. The relevant --help output lists the environment variables that can be set.
+
+For example, the output for `cargo-advent generate --help is:`
+
+```text
+Generate a rust project using the configuration supplied
+
+Usage: cargo-advent.exe generate [OPTIONS]
+
+Options:
+  -n, --project-name <PROJECT_NAME>  The name to use for the generated project. If not supplied will use name aoc-{aoc_year}-{aoc_day} [env: ADVENT_PROJECT_NAME=]
+  -t, --template <TEMPLATE>          The source of the template [env: ADVENT_TEMPLATE_URL=] [default: https://github.com/codersparks-aoc/aoc-rust-template.git]
+  -b, --base-url <BASE_URL>          The base url for the aoc website [env: ADVENT_BASE_URL=]
+  -y, --year <YEAR>                  The year the aoc puzzle was published. If not supplied will use current year [env: ADVENT_YEAR=]
+  -d, --day <DAY>                    The day the aoc puzzle was published. If not supplied will use current day [env: ADVENT_DAY=]
+  -p, --path <PATH>                  The path to use for where to create the project. Default ./{project_name} [env: ADVENT_PROJECT_PATH=]
+  -h, --help                         Print help
+```
+
+The setting for `-n`/`--project-name` can be set via the environment variable `ADVENT_PROJECT_NAME`. If there is a .env
+file in the current directory, it will be read and the environment variables will be available to the application. This
+expects that the variabless are in the format `<env_var>=<value>` with each variable on a new line for example the
+following would set the `-n`/`--project-name` and `-p`/`--path` parameters:
+
+```text
+ADVENT_PROJECT_NAME=my-project-name
+ADVENT_PROJECT_PATH=./my-project-path
+```
+
+The variables loaded from the .env file can be seen in the help output for the relevent subcommand. For example if the
+above example was used for the `generate` subcommand, the help output would be:
+
+```text
+...
+  -p, --path <PATH>                  The path to use for where to create the project. Default ./{project_name} [env: ADVENT_PROJECT_PATH=./my-project-path]
+...
+```

--- a/examples/env/.env-example
+++ b/examples/env/.env-example
@@ -1,0 +1,4 @@
+# This provides an example .env file, it is used during the development process to avoid having to manually
+# set environment variables, but is not commited by default to the repo in the root directory
+ADVENT_PROJECT_PATH=./dev-output
+ADVENT_VERBOSITY=3

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -1,12 +1,12 @@
-use crate::command_line::model::{GenerateRustProjectCliArgs, ModeSubCommands};
+use crate::command_line::cmd_line_model::{GenerateRustProjectCliArgs, ModeSubCommands};
 use cargo_advent::context::{AocData, AppAction, AppContext};
 use clap::Parser;
 use tracing::{debug, Level};
 
-mod model;
+mod cmd_line_model;
 
 pub fn parse_command_line() -> AppContext {
-    let cmd_args = model::RootCliArgs::parse();
+    let cmd_args = cmd_line_model::RootCliArgs::parse();
 
     let level = match cmd_args.verbosity {
         0 => Level::ERROR,
@@ -32,7 +32,7 @@ fn parse_generate_rust_project_args(data: GenerateRustProjectCliArgs) -> AppActi
     debug!("parsed aoc_data: {:#?}", aoc_data);
     let project_name = data
         .project_name
-        .unwrap_or_else(|| format!("aoc_{}_{}", aoc_data.year, aoc_data.day));
+        .unwrap_or_else(|| format!("aoc-{}-{}", aoc_data.year, aoc_data.day));
     debug!("parsed project_name: {}", project_name);
     let path = data.path.unwrap_or_else(|| "./".to_string());
     debug!("parsed path: {}", path);
@@ -46,7 +46,7 @@ fn parse_generate_rust_project_args(data: GenerateRustProjectCliArgs) -> AppActi
 
 #[cfg(test)]
 mod tests {
-    use crate::command_line::model::{ModeSubCommands, RootCliArgs};
+    use crate::command_line::cmd_line_model::{ModeSubCommands, RootCliArgs};
     use crate::command_line::parse_generate_rust_project_args;
     use cargo_advent::context::{AocData, AppAction};
     use chrono::{Datelike, Utc};

--- a/src/command_line/cmd_line_model.rs
+++ b/src/command_line/cmd_line_model.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 #[command(version, about, long_about = None)]
 pub struct RootCliArgs {
     /// Set the verbosity of the logging default ERROR, -v INFO, -vv DEBUG
-    #[arg(short, long, action=clap::ArgAction::Count)]
+    #[arg(short, long, action=clap::ArgAction::Count, env="ADVENT_VERBOSITY")]
     pub verbosity: u8,
     /// Provide the sub commands functionality
     #[command(subcommand)]
@@ -29,33 +29,34 @@ pub enum ModeSubCommands {
 #[derive(Debug, Clone, Args)]
 pub struct GenerateRustProjectCliArgs {
     /// The name to use for the generated project. If not supplied will use name aoc-{aoc_year}-{aoc_day}
-    #[arg(short = 'n', long)]
+    #[arg(short = 'n', long, env = "ADVENT_PROJECT_NAME")]
     pub project_name: Option<String>,
     /// The source of the template
     #[arg(
         short,
         long,
-        default_value = "https://github.com/codersparks-aoc/aoc-rust-template.git"
+        default_value = "https://github.com/codersparks-aoc/aoc-rust-template.git",
+        env = "ADVENT_TEMPLATE_URL"
     )]
     pub template: String,
     /// The data required for configuration for advent of code
     #[clap(flatten)]
     pub aoc_cli_args: AocCliArgs,
     /// The path to use for where to create the project. Default ./{project_name}
-    #[arg(short, long)]
+    #[arg(short, long, env = "ADVENT_PROJECT_PATH")]
     pub path: Option<String>,
 }
 
 #[derive(Debug, Clone, Args)]
 pub struct AocCliArgs {
     /// The base url for the aoc website
-    #[arg(short, long)]
+    #[arg(short, long, env = "ADVENT_BASE_URL")]
     pub base_url: Option<String>,
     /// The year the aoc puzzle was published. If not supplied will use current year
-    #[arg(short, long)]
+    #[arg(short, long, env = "ADVENT_YEAR")]
     pub year: Option<i32>,
     /// The day the aoc puzzle was published. If not supplied will use current day
-    #[arg(short, long)]
+    #[arg(short, long, env = "ADVENT_DAY")]
     pub day: Option<u32>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,4 +10,6 @@ pub type AdventResult<T> = Result<T, AdventError>;
 pub enum AdventError {
     #[error(transparent)]
     GenerateProjectError(#[from] GenerateProjectError),
+    #[error(".env file exists but could not be read: {0}")]
+    EnvLoadError(String),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,13 @@
-use cargo_advent::AdventResult;
+use cargo_advent::{AdventError, AdventResult};
 use tracing::debug;
 
 mod command_line;
 
 fn main() -> AdventResult<()> {
+    let load_env_success = loadenv::load().map_err(AdventError::EnvLoadError)?;
     let app_context = command_line::parse_command_line();
+    // We have to delay the output for the env file loading so that verbosity can be configured
+    debug!(".env was file found and loaded: {:#?}", load_env_success);
     debug!("{:#?}", app_context);
     app_context.run_action()
 }


### PR DESCRIPTION



## 🤖 New release

* `cargo-advent`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `cargo-advent` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.44.0/src/lints/enum_variant_added.ron

Failed in:
  variant AdventError:EnvLoadError in C:\Users\coder\AppData\Local\Temp\.tmphFoVeN\cargo-advent\src\lib.rs:14
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/codersparks-aoc/cargo-advent/compare/v0.1.0...v0.2.0) - 2025-09-23

### Added

- Allowed config of clap by env vars from .env file

### Other

- reworded tickets to issues in readme
- Updated readme with links to issues
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).