### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/codersparks-aoc/cargo-advent/compare/v0.1.0...v0.2.0) - 2025-09-23
+
+### Added
+
+- Allowed config of clap by env vars from .env file ([#13](https://github.com/codersparks-aoc/cargo-advent/pull/13))
+
+### Other
+
+- updated jetbrains config ([#15](https://github.com/codersparks-aoc/cargo-advent/pull/15))
+- reworded tickets to issues in readme
+- Updated readme with links to issues
+
 ## [0.1.0](https://github.com/codersparks-aoc/cargo-advent/compare/v0.0.2...v0.1.0) - 2025-09-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cargo-advent"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "cargo-generate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-advent"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 authors = ["codersparks <codersparks@users.noreply.github.com>"]
 description = "Yet another cli to help with Advent of Code challenges"


### PR DESCRIPTION



## 🤖 New release

* `cargo-advent`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `cargo-advent` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.44.0/src/lints/enum_variant_added.ron

Failed in:
  variant AdventError:EnvLoadError in C:\Users\coder\AppData\Local\Temp\.tmp0OuVe8\cargo-advent\src\lib.rs:14
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/codersparks-aoc/cargo-advent/compare/v0.1.0...v0.2.0) - 2025-09-23

### Added

- Allowed config of clap by env vars from .env file ([#13](https://github.com/codersparks-aoc/cargo-advent/pull/13))

### Other

- updated jetbrains config ([#15](https://github.com/codersparks-aoc/cargo-advent/pull/15))
- reworded tickets to issues in readme
- Updated readme with links to issues
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).